### PR TITLE
Corrections submission interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 rsconnect
 data/demo_survey_targets.csv
+data/corrections.RDS

--- a/R/make_data_explorer.R
+++ b/R/make_data_explorer.R
@@ -5,7 +5,7 @@
 make_datatable <- function(responses) {
   
   # create df with desired columns
-  response_table <- responses #|>
+  response_table <- respondent_info #|>
   #   select(
   #     date, time, response_id, name, facilitator_name, account_email,
   #     sector, gender, contains("born"), n_rep, opt_in) |> 
@@ -23,6 +23,7 @@ make_datatable <- function(responses) {
   table = datatable(response_table,
             filter = list(position = "top"),
             plugins = "accent-neutralise",
+            editable = TRUE,
             options = list(
               pageLength = 50,
               scrollX = TRUE,
@@ -62,7 +63,8 @@ make_dups_table <- function() {
 make_corrections_table <- function(corrections) {
   table <- datatable(
     corrections,
-    colnames = c("Response ID", "Correction"),
+    colnames = c("Response ID", "Correction", "User", "Date", "Fixed"),
+    escape = FALSE,
     options = list(
       lengthChange = FALSE,
       dom = "t",

--- a/R/make_data_explorer.R
+++ b/R/make_data_explorer.R
@@ -66,7 +66,7 @@ make_dups_table <- function() {
 make_corrections_table <- function(corrections) {
   table <- datatable(
     corrections,
-    colnames = c("Response ID", "Sector", "Correction", "User", "Date", "Fixed"),
+    colnames = c("Response ID", "Correction", "User", "Date", "Fixed"),
     escape = FALSE,
     options = list(
       pageLength = 50,

--- a/R/make_data_explorer.R
+++ b/R/make_data_explorer.R
@@ -18,7 +18,12 @@ make_datatable <- function(responses) {
       scroller = TRUE,
       lengthChange = FALSE
     )
-  )
+  ) |> 
+    # removes row striping
+    formatStyle(
+      columns = -1:ncol(responses) + 1,
+      "box-shadow" = "inset 0 0 0 9999px rgba(0, 0, 0, 0)"
+    )
   
   return(table)
 }
@@ -47,10 +52,11 @@ make_dups_table <- function() {
   datatable(
     exact_dups,
     colnames = c("Response ID", "Duplicate ID"),
+    class = list(stripe = FALSE),
     options = list(
       pageLength = 50,
       lengthChange = FALSE,
-      dom = "t"
+      dom = "t",
     )
   )
   
@@ -60,10 +66,10 @@ make_dups_table <- function() {
 make_corrections_table <- function(corrections) {
   table <- datatable(
     corrections,
-    colnames = c("Response ID", "Correction", "User", "Date", "Fixed"),
+    colnames = c("Response ID", "Sector", "Correction", "User", "Date", "Fixed"),
     escape = FALSE,
     options = list(
-      lengthChange = FALSE,
+      pageLength = 50,
       dom = "t",
       columnDefs = list(list(
         className = 'dt-center', targets = 1

--- a/R/make_data_explorer.R
+++ b/R/make_data_explorer.R
@@ -3,59 +3,56 @@
 
 # table for DT data explorer
 make_datatable <- function(responses) {
-  
   # create df with desired columns
-  response_table <- respondent_info #|>
-  #   select(
-  #     date, time, response_id, name, facilitator_name, account_email,
-  #     sector, gender, contains("born"), n_rep, opt_in) |> 
-  #   mutate(
-  #     response_id = as.character(response_id)) |> 
-  #   rename("Response ID" = response_id,
-  #          "Number of people represented" = n_rep,
-  #          "Opt in for review" = opt_in,
-  #          "Age" = yrborn)
-  # 
-  # colnames(response_table) <- gsub("_", " ",
-  #                                  str_to_title(colnames(response_table)))
+  response_table <- respondent_info 
   
   # output datatable object
-  table = datatable(response_table,
-            filter = list(position = "top"),
-            plugins = "accent-neutralise",
-            editable = TRUE,
-            options = list(
-              pageLength = 50,
-              scrollX = TRUE,
-              scroller = TRUE,
-              lengthChange = FALSE))
+  table = datatable(
+    response_table,
+    filter = list(position = "top"),
+    plugins = "accent-neutralise",
+    editable = TRUE,
+    options = list(
+      pageLength = 50,
+      scrollX = TRUE,
+      scroller = TRUE,
+      lengthChange = FALSE
+    )
+  )
   
   return(table)
 }
 
-# table of exact duplicate responses 
+# table of exact duplicate responses
 make_dups_table <- function() {
-  
-  exact_dups <- shapes[duplicated(shapes$geometry) | duplicated(shapes$geometry, fromLast = TRUE), ] |> 
-    select(response_id) |> 
+  exact_dups <-
+    shapes[duplicated(shapes$geometry) |
+             duplicated(shapes$geometry, fromLast = TRUE),] |>
+    select(response_id) |>
     # use area as means of summing shapes for comparison across response ids with multiple sector responses
-    mutate(area = as.numeric(st_area(.))) |> 
-    as.data.frame() |> 
-    group_by(response_id) |> 
-    summarize(area = sum(area)) |> 
-    group_by(area) |> 
+    mutate(area = as.numeric(st_area(.))) |>
+    as.data.frame() |>
+    group_by(response_id) |>
+    summarize(area = sum(area)) |>
+    group_by(area) |>
     # create identifier for identical response pairs / groups
-    mutate(duplicate_id = cur_group_id()) |> 
-    ungroup() |> 
+    mutate(duplicate_id = cur_group_id()) |>
+    ungroup() |>
     select(-area)
   
   n_dups <- nrow(exact_dups)
   
   assign("n_dups", n_dups, envir = .GlobalEnv)
   
-  datatable(exact_dups,
-            colnames = c("Response ID", "Duplicate ID"),
-            options = list(pageLength = 50, lengthChange = FALSE, dom = "t"))
+  datatable(
+    exact_dups,
+    colnames = c("Response ID", "Duplicate ID"),
+    options = list(
+      pageLength = 50,
+      lengthChange = FALSE,
+      dom = "t"
+    )
+  )
   
 }
 
@@ -72,13 +69,12 @@ make_corrections_table <- function(corrections) {
         className = 'dt-center', targets = 1
       ))
     )
-  )
+  ) |>
+    formatStyle(
+      columns = 0:ncol(corrections),
+      valueColumns = "fixed",
+      backgroundColor = styleEqual("✅", "#dbf5d7")
+    )
   
   return(table)
 }
-
-
-
-
-
-

--- a/R/make_data_explorer.R
+++ b/R/make_data_explorer.R
@@ -58,6 +58,23 @@ make_dups_table <- function() {
   
 }
 
+# data corrections table
+make_corrections_table <- function(corrections) {
+  table <- datatable(
+    corrections,
+    colnames = c("Response ID", "Correction"),
+    options = list(
+      lengthChange = FALSE,
+      dom = "t",
+      columnDefs = list(list(
+        className = 'dt-center', targets = 1
+      ))
+    )
+  )
+  
+  return(table)
+}
+
 
 
 

--- a/R/make_target_table.R
+++ b/R/make_target_table.R
@@ -44,16 +44,6 @@ make_target_table <- function(responses) {
       metric = "recreation_sports_and_tourism_sector"
     )
   
-  sci_tech <- responses |>
-    filter(
-      sector == "Scientific Research, Technological Development and Environmental Monitoring"
-    ) |>
-    summarize(
-      individuals = n(),
-      represented = sum(n_rep),
-      metric = "science_tech_and_monitoring_sector"
-    )
-  
   aquaculture <- responses |>
     filter(sector == "Aquaculture") |>
     summarize(
@@ -116,7 +106,6 @@ make_target_table <- function(responses) {
       population,
       research,
       rec_sports,
-      sci_tech,
       aquaculture,
       sec_def,
       energy_dev,

--- a/R/make_target_table.R
+++ b/R/make_target_table.R
@@ -76,13 +76,6 @@ make_target_table <- function(responses) {
       metric = "energy_development_sector"
     )
   
-  vessels <- responses |>
-    summarize(
-      individuals = length(unique(vessel_id)),
-      represented = NA,
-      metric = "vessels"
-    )
-  
   
   population <- responses |>
     select(response_id, n_rep) |>
@@ -102,7 +95,6 @@ make_target_table <- function(responses) {
       rec_fishing,
       comm_fishing,
       tour_fishing,
-      vessels,
       population,
       research,
       rec_sports,
@@ -186,37 +178,17 @@ make_target_table <- function(responses) {
         ))
       )
     ) |>
-    # highlight column of metric (rep or indiv) that is associated with "percent achieved"
-    formatStyle(
-      columns = "individuals",
-      valueColumns = "metric",
-      backgroundColor = styleEqual(unique(targets_progress$metric[!str_detect(targets_progress$metric, "Sector|Population")]),
-                                   "#eefafa"),
-      border = styleEqual(unique(targets_progress$metric[!str_detect(targets_progress$metric, "Sector|Population")]),
-                          '0.1px solid #b8b8b8'),
-      "border-radius" = styleEqual(unique(targets_progress$metric[!str_detect(targets_progress$metric, "Sector|Population")]),
-                                   '5px'),
-      fontWeight = styleEqual(unique(targets_progress$metric[!str_detect(targets_progress$metric, "Sector|Population")]),
-                              "bold")
-    ) |>
-    formatStyle(
-      columns = "represented",
-      valueColumns = "metric",
-      backgroundColor = styleEqual(unique(targets_progress$metric[str_detect(targets_progress$metric, "Sector|Population")]),
-                                   "#eefafa"),
-      border = styleEqual(unique(targets_progress$metric[str_detect(targets_progress$metric, "Sector|Population")]),
-                          '0.1px solid #b8b8b8'),
-      "border-radius" = styleEqual(unique(targets_progress$metric[str_detect(targets_progress$metric, "Sector|Population")]),
-                                   '5px'),
-      fontWeight = styleEqual(unique(targets_progress$metric[str_detect(targets_progress$metric, "Sector|Population")]),
-                              "bold")
-    ) |>
     # percent color ramp formatting
     formatStyle(
       columns = "percent",
       backgroundColor = styleInterval(breaks, colors),
       "border-radius" = "5px"
     ) |>
+    # removes row striping
+    formatStyle(
+      columns = -1:ncol(targets_progress) + 1,
+      "box-shadow" = "inset 0 0 0 9999px rgba(0, 0, 0, 0)"
+    ) |> 
     formatPercentage(columns = "percent",
                      mark = ".",
                      digits = 0)

--- a/global.R
+++ b/global.R
@@ -16,7 +16,7 @@ library(ggchicklet)
 library(snakecase)
 library(lubridate)
 
-secure <- T
+secure <- F
 
 project <- "demo"
 

--- a/global.R
+++ b/global.R
@@ -16,7 +16,7 @@ library(ggchicklet)
 library(snakecase)
 library(lubridate)
 
-secure <- F
+secure <- T
 
 project <- "demo"
 

--- a/runApp.R
+++ b/runApp.R
@@ -1,0 +1,1 @@
+shiny::runApp(launch.browser = TRUE, host = "127.0.0.1", port = 5406)

--- a/server.R
+++ b/server.R
@@ -204,11 +204,33 @@ shinyServer(function(input, output, session) {
     
   })
   
+  # data corrections
+  
+  corrections <- read_rds("data/corrections.RDS")
+  
+  output$corrections_table <-
+    renderDataTable(make_corrections_table(corrections))
+  
+  observeEvent(input$submit_correction, {
+    new_entry <- data.frame(
+      response_id = input$corrections_response_id,
+      correction = input$corrections_text
+    )
+    corrections <- bind_rows(list(corrections, new_entry))
+    
+    print(corrections)
+    
+    output$corrections_table <-
+      renderDataTable(make_corrections_table(corrections))
+    
+    write_rds(corrections, "data/corrections.RDS")
+    
+  })
+  
   output$n_dups <- renderText(nrow("n_dups"))
   outputOptions(output, "n_dups", suspendWhenHidden = FALSE)
   
   output$dup_table <- renderDataTable(make_dups_table())
-  
   
   
   # Shape viewer -------------------------------------------------

--- a/server.R
+++ b/server.R
@@ -1,7 +1,7 @@
 # Define server logic
 
 shinyServer(function(input, output, session) {
-  # user auth --------------------------------
+  # USER AUTH --------------------------------
   
   # read in db passphrase
   passphrase_file <- "auth/passphrase.txt"
@@ -27,7 +27,7 @@ shinyServer(function(input, output, session) {
     reactiveValuesToList(res_auth)$user
   })
   
-  # reactive file reading ---------------------------------------
+  # FILE READING ---------------------------------------
   
   # responses
   responses_reader <- reactiveFileReader(
@@ -71,12 +71,14 @@ shinyServer(function(input, output, session) {
   data_update <- reactive(data_update_reader() |>
                             as_datetime(tz = "America/Los_Angeles"))
   
-  # refresh app button ----
+  # REFRESH APP ----------------------------------------------
   observeEvent(input$refresh, {
     shinyjs::js$refresh_page()
   })
   
-  # info boxes ------------------------------------------------
+  # OVERVIEW ------------------------------------------------
+  
+  ## info boxes ----
   
   # latest data update
   output$latest_data <- renderUI({
@@ -110,15 +112,16 @@ shinyServer(function(input, output, session) {
   })
   
   
-  # targets ------------------------------------------------
+  ## targets ------------------------------------------------
   
-  # target table
+  ### target table ----
   output$target_table <- renderDataTable({
     make_target_table(responses = responses())
   })
   
-  # admin only - allow writing target changes to local csv
+  ### target editing ----
   observe({
+    # admin only - allow writing target changes to local csv
     if (!is.null(write_status()) && write_status() == TRUE) {
       
       # make target_table_reactive object reactive so the save_targets event can access the current changes
@@ -170,14 +173,14 @@ shinyServer(function(input, output, session) {
   })
   
   
-  # demographic plot ---------------------
+  ## demographic plot ----
   
   output$demo_plot <- renderPlot({
     make_demo_plot(respondent_info = respondent_info())
     
   })
   
-  # Sector plot ------------------------------------
+  ## sector plot ------------------------------------
   
   # initially define metric that can be changed with the box dropdown menu
   resp_plot_metric <- reactiveVal()
@@ -242,6 +245,7 @@ shinyServer(function(input, output, session) {
   
   corrections_proxy <- dataTableProxy("corrections_table")
   
+  # submit new correction
   observeEvent(input$submit_correction, {
     
     if (is.na(input$corrections_response_id) | input$corrections_text == "") {
@@ -278,6 +282,7 @@ shinyServer(function(input, output, session) {
     
   })
   
+  # mark entry as fixed
   observeEvent(input$mark_fixed, {
     selected_rows <- input$corrections_table_rows_selected
     
@@ -305,7 +310,7 @@ shinyServer(function(input, output, session) {
   output$dup_table <- renderDataTable(make_dups_table())
   
   
-  # Shape viewer -------------------------------------------------
+  # SHAPE VIEWER -------------------------------------------------
   
   output$map <- renderLeaflet({
     #
@@ -476,7 +481,7 @@ shinyServer(function(input, output, session) {
   
   output$reporting_by_sector_title <- renderText("By Sector")
   
-  # download reporting CSVs
+  ## download CSVs ----
   
   data_report_totals <- reactive(reporting_totals)
   

--- a/server.R
+++ b/server.R
@@ -250,31 +250,33 @@ shinyServer(function(input, output, session) {
     } else {
       new_entry <- data.frame(
         response_id = input$corrections_response_id,
-        sector = input$corrections_sector,
         correction = input$corrections_text,
         user = ifelse(class(current_user()) == "character", current_user(), NA),
         date = now(),
         fixed = "⬜️"
       )
       
-      new_corrections <- bind_rows(list(corrections(), new_entry))
-      
-      corrections(new_corrections)
-      
-      replaceData(corrections_proxy, new_corrections)
-      
-      write_rds(corrections(), "data/corrections.RDS")
-      
-      updateNumericInput(inputId = "corrections_response_id",
-                         value = numeric(0))
-      updateTextAreaInput(inputId = "corrections_text",
-                          value = character(0))
-      
+      # make sure response_id exists in data - show warning if not
+      if (new_entry[["response_id"]] %in% responses()$response_id) {
+        new_corrections <- bind_rows(list(corrections(), new_entry))
+        
+        corrections(new_corrections)
+        
+        replaceData(corrections_proxy, new_corrections)
+        
+        write_rds(corrections(), "data/corrections.RDS")
+        
+        updateNumericInput(inputId = "corrections_response_id",
+                           value = numeric(0))
+        updateTextAreaInput(inputId = "corrections_text",
+                            value = character(0))
+      } else {
+        showNotification("The submitted response ID doesn't exist in the dataset",
+                         type = "error")
+      }
     }
     
   })
-  
-  # corrections_proxy <- dataTableProxy("corrections_table")
   
   observeEvent(input$mark_fixed, {
     selected_rows <- input$corrections_table_rows_selected

--- a/ui.R
+++ b/ui.R
@@ -217,14 +217,8 @@ ui <- (dashboardPage(
                           "corrections_response_id",
                           "Response ID:",
                           NA,
-                          width = "25%"), 
-                        selectInput(
-                          "corrections_sector",
-                          "Sector:",
-                          choices = as.character(unique(responses$sector)),
-                          selected = NULL,
                           width = "25%"
-                        ),
+                          ),
                         textAreaInput(
                           "corrections_text",
                           "Corrections to be made:",

--- a/ui.R
+++ b/ui.R
@@ -206,6 +206,33 @@ dashboardPage(
                           withSpinner(type = 8)
                         
                       ),
+                      
+                      # corrections tab
+                      tabPanel(
+                        title = "Corrections",
+                        
+                        actionBttn(
+                          "submit_correction",
+                          "Submit Correction",
+                          style = "jelly",
+                          size = "sm",
+                          icon = icon("save")
+                        ),
+                        
+                        tags$br(),
+                        tags$br(),
+                        
+                        numericInput("corrections_response_id", "Response ID", NA),
+                        textAreaInput("corrections_text", "Corrections to be made"),
+                        
+                        shinydashboardPlus::box(
+                          width = 12,
+                          
+                          dataTableOutput("corrections_table") |>
+                            withSpinner(type = 8)
+                        )
+                      ), 
+                      
                       # duplicates tab - only displays table if dups exist
                       tabPanel(
                         title = "Duplicates",
@@ -215,8 +242,6 @@ dashboardPage(
                                          HTML(
                                            paste0(br(), "No duplicate responses found")
                                          ))
-                        
-                        
                       )
                     )
                   ))),

--- a/ui.R
+++ b/ui.R
@@ -63,7 +63,7 @@ ui <- (dashboardPage(
       tabItem(
         tabName = "overview",
         
-        # value boxes --------------------------------
+        ## value boxes ----
         fluidRow(
           width = "100%",
           
@@ -115,7 +115,7 @@ ui <- (dashboardPage(
             )
           ),
           
-          # target table ----
+          ## target table ----
           div(
             id = "target-box",
             class = "col-sm-12 col-md-12 col-lg-12",
@@ -138,7 +138,7 @@ ui <- (dashboardPage(
         
         
         
-        # plots --------------------------------------------------------
+        ## plots ----
         
         div(id = "plots-row",
             fluidRow(
@@ -184,6 +184,7 @@ ui <- (dashboardPage(
       # DATA TABLE ----------------------------------------------------------
       tabItem(tabName = "explore",
               
+              ## main tab ----
               div(id = "dt-box",
                   box(
                     width = "100%",
@@ -206,7 +207,7 @@ ui <- (dashboardPage(
                         
                       ),
                       
-                      # corrections tab
+                      ## corrections ----
                       tabPanel(
                         title = "Corrections",
                         
@@ -215,33 +216,46 @@ ui <- (dashboardPage(
                           "Submit Correction",
                           style = "jelly",
                           size = "sm",
-                          icon = icon("save")
+                          icon = icon("upload")
+                        ),
+                        
+                        actionBttn(
+                          "mark_fixed",
+                          "Mark / Unmark as Fixed",
+                          style = "jelly",
+                          size = "sm",
+                          icon = icon("check")
                         ),
                         
                         tags$br(),
                         tags$br(),
+                        tags$br(),
                         
-                        numericInput("corrections_response_id", "Response ID", NA),
-                        textAreaInput("corrections_text", "Corrections to be made"),
+                        numericInput("corrections_response_id", "Response ID", NA,
+                                     width = "25%"),
+                        textAreaInput("corrections_text",
+                                      "Corrections to be made",
+                                      resize = "vertical"), 
+                        tags$br(),
+                        tags$br(),
                         
                         shinydashboardPlus::box(
                           width = 12,
                           
-                          dataTableOutput("corrections_table") |>
-                            withSpinner(type = 8)
+                          dataTableOutput("corrections_table")
                         )
                       ), 
                       
-                      # duplicates tab - only displays table if dups exist
-                      tabPanel(
-                        title = "Duplicates",
-                        conditionalPanel(condition = "output.n_dups!='0'",
-                                         dataTableOutput("dup_table", width = "50%")),
-                        conditionalPanel(condition = "output.n_dups=='0'",
-                                         HTML(
-                                           paste0(br(), "No duplicate responses found")
-                                         ))
-                      )
+                      ## duplicates ----
+                      # tabPanel(
+                      #   title = "Duplicates",
+                      #   conditionalPanel(condition = "output.n_dups!='0'",
+                      #                    dataTableOutput("dup_table", width = "50%")),
+                      #   conditionalPanel(condition = "output.n_dups=='0'",
+                      #                    HTML(
+                      #                      paste0(br(), "No duplicate responses found")
+                      #                    ))
+                      # )
                     )
                   ))),
       

--- a/ui.R
+++ b/ui.R
@@ -210,36 +210,54 @@ ui <- (dashboardPage(
                       ## corrections ----
                       tabPanel(
                         title = "Corrections",
-                        
-                        actionBttn(
-                          "submit_correction",
-                          "Submit Correction",
-                          style = "jelly",
-                          size = "sm",
-                          icon = icon("upload")
-                        ),
-                        
-                        actionBttn(
-                          "mark_fixed",
-                          "Mark / Unmark as Fixed",
-                          style = "jelly",
-                          size = "sm",
-                          icon = icon("check")
-                        ),
-                        
-                        tags$br(),
-                        tags$br(),
+                  
                         tags$br(),
                         
-                        numericInput("corrections_response_id", "Response ID", NA,
+                        numericInput("corrections_response_id", "Response ID:", NA,
                                      width = "25%"),
                         textAreaInput("corrections_text",
-                                      "Corrections to be made",
+                                      "Corrections to be made:",
                                       resize = "vertical"), 
-                        tags$br(),
+                        
                         tags$br(),
                         
+                        # actionBttn(
+                        #   "submit_correction",
+                        #   "Submit Correction",
+                        #   style = "jelly",
+                        #   size = "sm",
+                        #   icon = icon("upload")
+                        # ),
+                        
+                        # actionBttn(
+                        #   "mark_fixed",
+                        #   "Mark / Unmark as Fixed",
+                        #   style = "jelly",
+                        #   size = "sm",
+                        #   icon = icon("check")
+                        # ),
+                        
                         shinydashboardPlus::box(
+                          title = p(
+                            div(
+                              id = "corrections_title",
+                              "Corrections",
+                              actionBttn(
+                                "mark_fixed",
+                                "Mark fixed",
+                                style = "jelly",
+                                size = "md",
+                                icon = icon("check")
+                              ),
+                              actionBttn(
+                                "submit_correction",
+                                "Submit new ",
+                                style = "jelly",
+                                size = "md",
+                                icon = icon("upload")
+                              )
+                            )
+                          ),
                           width = 12,
                           
                           dataTableOutput("corrections_table")

--- a/ui.R
+++ b/ui.R
@@ -197,7 +197,7 @@ ui <- (dashboardPage(
                         actionBttn(
                           "dt_view_shapes",
                           "View in Map",
-                          style = "jelly",
+                          style = "simple",
                           size = "sm",
                           icon = icon("map")
                         ),
@@ -210,59 +210,54 @@ ui <- (dashboardPage(
                       ## corrections ----
                       tabPanel(
                         title = "Corrections",
-                  
-                        tags$br(),
-                        
-                        numericInput("corrections_response_id", "Response ID:", NA,
-                                     width = "25%"),
-                        textAreaInput("corrections_text",
-                                      "Corrections to be made:",
-                                      resize = "vertical"), 
                         
                         tags$br(),
                         
-                        # actionBttn(
-                        #   "submit_correction",
-                        #   "Submit Correction",
-                        #   style = "jelly",
-                        #   size = "sm",
-                        #   icon = icon("upload")
-                        # ),
+                        numericInput(
+                          "corrections_response_id",
+                          "Response ID:",
+                          NA,
+                          width = "25%"), 
+                        selectInput(
+                          "corrections_sector",
+                          "Sector:",
+                          choices = as.character(unique(responses$sector)),
+                          selected = NULL,
+                          width = "25%"
+                        ),
+                        textAreaInput(
+                          "corrections_text",
+                          "Corrections to be made:",
+                          resize = "vertical",
+                          width = "50%"
+                        ),
                         
-                        # actionBttn(
-                        #   "mark_fixed",
-                        #   "Mark / Unmark as Fixed",
-                        #   style = "jelly",
-                        #   size = "sm",
-                        #   icon = icon("check")
-                        # ),
+                        tags$br(),
                         
                         shinydashboardPlus::box(
-                          title = p(
-                            div(
-                              id = "corrections_title",
-                              "Corrections",
-                              actionBttn(
-                                "mark_fixed",
-                                "Mark fixed",
-                                style = "jelly",
-                                size = "md",
-                                icon = icon("check")
-                              ),
-                              actionBttn(
-                                "submit_correction",
-                                "Submit new ",
-                                style = "jelly",
-                                size = "md",
-                                icon = icon("upload")
-                              )
+                          id = "corrections_box",
+                          title = p(div(
+                            id = "corrections_title",
+                            actionBttn(
+                              "mark_fixed",
+                              "Mark fixed",
+                              style = "simple",
+                              size = "md",
+                              icon = icon("check")
+                            ),
+                            actionBttn(
+                              "submit_correction",
+                              "Submit new ",
+                              style = "simple",
+                              size = "md",
+                              icon = icon("plus")
                             )
-                          ),
+                          )),
                           width = 12,
                           
                           dataTableOutput("corrections_table")
                         )
-                      ), 
+                      ),
                       
                       ## duplicates ----
                       # tabPanel(
@@ -291,7 +286,7 @@ ui <- (dashboardPage(
                     actionBttn(
                       "clear_shape_filters",
                       "Clear Map & Filters",
-                      style = "jelly",
+                      style = "simple",
                       size = "sm",
                       icon = icon("refresh")
                     ),
@@ -300,7 +295,7 @@ ui <- (dashboardPage(
                     downloadBttn(
                       "download_filtered_shapes",
                       "Export Current Shapes",
-                      style = "jelly",
+                      style = "simple",
                       size = "sm",
                     ),
                     
@@ -385,7 +380,7 @@ ui <- (dashboardPage(
               "download_report_totals",
               "Download",
               size = "sm",
-              style = "jelly"
+              style = "simple"
             ),
             
             dataTableOutput("reporting_totals_table") |>
@@ -404,7 +399,7 @@ ui <- (dashboardPage(
               "download_report_sector",
               "Download",
               size = "sm",
-              style = "jelly"
+              style = "simple"
             ),
             
             dataTableOutput("reporting_by_sector_table") |>

--- a/www/style.css
+++ b/www/style.css
@@ -11,11 +11,15 @@ html, body {
   background-color: #F3F4F6;
 }
 
+.navbar {
+  background-color: #00A6E1 !important;
+}
+
 /* box titles */
 .box-title {
   font-weight: bold; 
   font-size: 30px !important;
-  color: #2B7EC2;
+  color: #00A6E1;
   padding-left: 10px;
 }
 
@@ -53,6 +57,23 @@ html, body {
  
  .box .box-solid {
    padding: 0px !important;
+ }
+ 
+ .action-button {
+   border-radius: 10px;
+ }
+ 
+ /* user input boxes */
+ .shiny-input-textarea {
+   border-radius: 6px;
+ }
+ 
+  .shiny-input-text {
+   border-radius: 6px;
+ }
+ 
+  .shiny-input-number {
+   border-radius: 6px;
  }
  
  .nav-tabs-custom {
@@ -188,10 +209,14 @@ html, body {
  
  /* ---- datatable page ---- */
  
+ #DataTables_Table_0 {
+   box-shadow: inset 0 0 0 9999px rgba(0, 0, 0, 0) !important;
+ }
+ 
   #dt_view_shapes {
    margin-top: 10px;
    margin-bottom: 0px;
-   background-color: #2B7EC2;
+   background-color: #00A6E1;
    color: white;
  }
  
@@ -211,20 +236,13 @@ html, body {
    background-color: #00A6E1;
    color: white;
    float: right;
-   margin-right: 10px;
+   margin-right: 15px;
  }
  
   #mark_fixed {
    background-color: #00A6E1;
    color: white;
    float: right;
- }
- 
- #corrections_title {
-   display: inline-block;
-   width: 73vw;
-   max-width: 1300px;
-   min-width: 50px;
  }
  
  /* ---- shape viewer page ---- */
@@ -234,14 +252,14 @@ html, body {
  
  #select_all_map_regions {
    margin-bottom: 15px;
-   border-color: #2B7EC2;
-   color: #2B7EC2;
+   border-color: #00A6E1;
+   color: #00A6E1;
  }
  
   #deselect_all_map_regions {
    margin-bottom: 15px;
-   border-color: #2B7EC2;
-   color: #2B7EC2;
+   border-color: #00A6E1;
+   color: #00A6E1;
  }
  
  #region_text {
@@ -272,14 +290,14 @@ html, body {
  }
  
  #clear_shape_filters {
-   background-color: #2B7EC2;
+   background-color: #00A6E1;
    color: white;
    margin-bottom: 20px;
    margin-right: 10px;
  }
  
  #download_filtered_shapes_bttn {
-   background-color: #2B7EC2;
+   background-color: #00A6E1;
    color: white;
    margin-bottom: 20px;
  }
@@ -303,21 +321,21 @@ html, body {
  #download_report_totals_bttn {
    float: right;
    display: inline-block;
-   background-color: #2B7EC2;
+   background-color: #00A6E1;
    color: white;
  }
  
   #download_report_sector_bttn {
    float: right;
    display: inline-block;
-   background-color: #2B7EC2;
+   background-color: #00A6E1;
    color: white;
  }
   
  #reporting_totals_title {
    font-weight: bold; 
    font-size: 30px !important;
-   color: #2B7EC2;
+   color: #00A6E1;
    padding-left: 10px;
    display: inline-block;
  }
@@ -325,7 +343,7 @@ html, body {
   #reporting_by_sector_title {
    font-weight: bold; 
    font-size: 30px !important;
-   color: #2B7EC2;
+   color: #00A6E1;
    padding-left: 10px;
    display: inline-block;
  }

--- a/www/style.css
+++ b/www/style.css
@@ -207,7 +207,11 @@ html, body {
    max-width: 1400px !important;
  }
  
- 
+   #submit_correction {
+   background-color: #2B7EC2;
+   color: white;
+   float: right;
+ }
  
  
  /* ---- shape viewer page ---- */

--- a/www/style.css
+++ b/www/style.css
@@ -208,16 +208,23 @@ html, body {
  }
  
   #submit_correction {
-   margin-top: 10px;
-   margin-right: 10px;
-   background-color: #2B7EC2;
+   background-color: #00A6E1;
    color: white;
+   float: right;
+   margin-right: 10px;
  }
  
   #mark_fixed {
-   margin-top: 10px !important;
-   background-color: #2B7EC2;
+   background-color: #00A6E1;
    color: white;
+   float: right;
+ }
+ 
+ #corrections_title {
+   display: inline-block;
+   width: 73vw;
+   max-width: 1300px;
+   min-width: 50px;
  }
  
  /* ---- shape viewer page ---- */

--- a/www/style.css
+++ b/www/style.css
@@ -207,12 +207,18 @@ html, body {
    max-width: 1400px !important;
  }
  
-   #submit_correction {
+  #submit_correction {
+   margin-top: 10px;
+   margin-right: 10px;
    background-color: #2B7EC2;
    color: white;
-   float: right;
  }
  
+  #mark_fixed {
+   margin-top: 10px !important;
+   background-color: #2B7EC2;
+   color: white;
+ }
  
  /* ---- shape viewer page ---- */
  #map {


### PR DESCRIPTION
Adds a "corrections" tab to the data explorer that lets users submit edits that need to be made to the data. 

Ideas for future features:
 - write-access ability to edit and delete entries
 - only write-access users can "mark as fixed"
 - marking as fixed prompts user to identify where they made the corrections (in shiny app or seasketch)