### PR TITLE
overview page formatting, tooltips, and improved datatable filtering

### DIFF
--- a/R/make_datatable.R
+++ b/R/make_datatable.R
@@ -3,8 +3,9 @@
 
 # table for DT data explorer
 make_datatable <- function(responses, edit_data_status) {
-  # create df with desired columns
-  response_table <- responses 
+  # create df with desired column types (for better filtering)
+  response_table <- responses |> 
+    mutate(response_id = as.character(response_id))
   
   
   if (edit_data_status == FALSE) {

--- a/server.R
+++ b/server.R
@@ -93,7 +93,7 @@ shinyServer(function(input, output, session) {
   # datetime update box
   output$data_update <- renderValueBox({
     valueBox(
-      "Responses Updated:",
+      HTML("Responses</br>Updated:"),
       HTML(data_update() |> str_replace(" ", "</br>")),
       icon = icon("database")
     )

--- a/server.R
+++ b/server.R
@@ -90,16 +90,20 @@ shinyServer(function(input, output, session) {
   
   ## info boxes ----
   
-  # latest data update
-  output$latest_data <- renderUI({
-    HTML(paste0("Data updated", br(), "<b>", data_update(), "</b>"))
+  # datetime update box
+  output$data_update <- renderValueBox({
+    valueBox(
+      "Responses Updated:",
+      HTML(data_update() |> str_replace(" ", "</br>")),
+      icon = icon("database")
+    )
   })
   
   # number respondents box
   output$individual_respondents <- renderValueBox({
     valueBox(
       length(unique(responses_reactive()$response_id)),
-      HTML(paste0("Individual", br(), "Respondents")),
+      HTML(paste0("Individual", br(), "Responses")),
       icon = icon("user", class = "fa-solid fa-user")
     )
   })
@@ -108,7 +112,7 @@ shinyServer(function(input, output, session) {
   output$individuals_represented <- renderValueBox({
     valueBox(
       sum(respondent_info()$participants),
-      HTML(paste0("Individuals", br(), "Represented")),
+      HTML(paste0("Participants", br(), "Represented")),
       icon = icon("users")
     )
   })

--- a/ui.R
+++ b/ui.R
@@ -52,128 +52,131 @@ ui <- (dashboardPage(
       tabItem(
         tabName = "overview",
         
-        ## value boxes ----
-        fluidRow(
-          width = "100%",
-          
-          # top row of boxes
-          div(
-            class = "col-sm-12 col-md-12 col-lg-12",
-            id = "top-row",
+        div(
+          id = "overview-tab",
+          ## value boxes ----
+          fluidRow(
+            width = "100%",
             
-            # latest data and island option stack
+            # top row of boxes
             div(
-              id = "data-island-stack",
-              class = "col-sm-6 col-md-6 col-lg-3",
+              class = "col-sm-12 col-md-12 col-lg-12",
+              id = "top-row",
               
-              # latest data text
+              # latest data and island option stack
               div(
-                id = "latest-data",
-                class = "col-sm-12 col-md-12 col-lg-12",
-                div(id = "latest-data-box",
-                    box(
-                      tags$a(
-                        href = seasketch_url,
-                        target = "_blank",
-                        img(src = "images/seasketch-logo.png",
-                            style = "height: 35px; margin-bottom: 17px; margin-top: 10px;"),
+                id = "data-island-stack",
+                class = "col-sm-6 col-md-6 col-lg-3",
+                
+                # latest data text
+                div(
+                  id = "latest-data",
+                  class = "col-sm-12 col-md-12 col-lg-12",
+                  div(id = "latest-data-box",
+                      box(
+                        tags$a(
+                          href = seasketch_url,
+                          target = "_blank",
+                          img(src = "images/seasketch-logo.png",
+                              style = "height: 35px; margin-bottom: 17px; margin-top: 10px;"),
+                          width = "100%"
+                        ),
+                        
+                        uiOutput("latest_data"),
                         width = "100%"
-                        # height = "62px"
-                      ),
-                      
-                      uiOutput("latest_data"),
-                      width = "100%"
-                    ))
+                      ))
+                ),
               ),
+              
+              # value box row
+              div(
+                id = "value-box-row",
+                class = "col-sm-12 col-md-12 col-lg-9",
+                
+                # value boxes with response and representation figures
+                div(class = "col-sm-4 col-md-4 col-lg-4",
+                    valueBoxOutput("individual_respondents", width = "33%")),
+                
+                div(class = "col-sm-4 col-md-4 col-lg-4",
+                    valueBoxOutput("individuals_represented", width = "33%")),
+                
+                div(class = "col-sm-4 col-md-4 col-lg-4",
+                    valueBoxOutput("sector_responses", width = "33%"))
+              )
             ),
             
-            # value box row
+            ## target table ----
             div(
-              id = "value-box-row",
-              class = "col-sm-12 col-md-12 col-lg-9",
+              id = "target-box",
+              class = "col-sm-12 col-md-12 col-lg-12",
               
-              # value boxes with response and representation figures
-              div(class = "col-sm-4 col-md-4 col-lg-4",
-                  valueBoxOutput("individual_respondents", width = "33%")),
-              
-              div(class = "col-sm-4 col-md-4 col-lg-4",
-                  valueBoxOutput("individuals_represented", width = "33%")),
-              
-              div(class = "col-sm-4 col-md-4 col-lg-4",
-                  valueBoxOutput("sector_responses", width = "33%"))
+              shinydashboardPlus::box(
+                title = "Targets",
+                width = 12,
+                align = "center",
+                collapsible = TRUE,
+                dropdownMenu = shinydashboardPlus::boxDropdown(
+                  shinydashboardPlus::boxDropdownItem("Save target changes", id = "save_targets")
+                ),
+                
+                DT::dataTableOutput("target_table") |>
+                  shinycssloaders::withSpinner(type = 8)
+              )
             )
           ),
           
-          ## target table ----
-          div(
-            id = "target-box",
-            class = "col-sm-12 col-md-12 col-lg-12",
-            
-            shinydashboardPlus::box(
-              title = "Targets",
-              width = 12,
-              align = "center",
-              collapsible = TRUE,
-              dropdownMenu = shinydashboardPlus::boxDropdown(
-                shinydashboardPlus::boxDropdownItem("Save target changes", id = "save_targets")
-              ),
-              
-              DT::dataTableOutput("target_table") |>
-                shinycssloaders::withSpinner(type = 8)
-            )
-          )
-        ),
-        
-        
-        
-        
-        ## plots ----
-        
-        div(id = "plots-row",
-            fluidRow(
-              # sector responses
-              div(
-                class = "col-sm-12 col-md-12 col-lg-6",
-                id = "resp-plot-box",
-                
-                shinydashboardPlus::box(
-                  title = "Responses by Sector",
-                  width = 12,
-                  collapsible = TRUE,
+          
+          
+          
+          ## plots ----
+          div(id = "plots-row",
+              class = "col-sm-12 col-md-12 col-lg-12",
+              fluidRow(
+                # sector responses
+                div(
+                  class = "col-sm-12 col-md-12 col-lg-6",
+                  id = "resp-plot-box",
                   
-                  dropdownMenu = shinydashboardPlus::boxDropdown(
-                    shinydashboardPlus::boxDropdownItem("Represented", id = "represented"),
-                    shinydashboardPlus::boxDropdownItem("Responses", id = "responses")
+                  shinydashboardPlus::box(
+                    title = "Responses by Sector",
+                    width = 12,
+                    collapsible = TRUE,
                     
-                  ),
-                  
-                  plotOutput("resp_plot") |>
-                    shinycssloaders::withSpinner(type = 8)
-                )
-              ),
-              
-              
-              # demographics
-              div(
-                class = "col-sm-12 col-md-12 col-lg-6",
-                id = "demo-plot-box",
-                
-                shinydashboardPlus::box(
-                  title = "Demographics",
-                  width = 12,
-                  collapsible = TRUE,
-                  
-                  dropdownMenu = shinydashboardPlus::boxDropdown(
-                    shinydashboardPlus::boxDropdownItem("Age", id = "age"),
-                    shinydashboardPlus::boxDropdownItem("Gender", id = "gender")
+                    dropdownMenu = shinydashboardPlus::boxDropdown(
+                      shinydashboardPlus::boxDropdownItem("Represented", id = "represented"),
+                      shinydashboardPlus::boxDropdownItem("Responses", id = "responses")
+                      
+                    ),
                     
-                  ),
+                    plotOutput("resp_plot") |>
+                      shinycssloaders::withSpinner(type = 8)
+                  )
+                ),
+                
+                
+                # demographics
+                div(
+                  class = "col-sm-12 col-md-12 col-lg-6",
+                  id = "demo-plot-box",
                   
-                  plotOutput("demo_plot") |>
-                    shinycssloaders::withSpinner(type = 8)
+                  shinydashboardPlus::box(
+                    title = "Demographics",
+                    width = 12,
+                    collapsible = TRUE,
+                    
+                    dropdownMenu = shinydashboardPlus::boxDropdown(
+                      shinydashboardPlus::boxDropdownItem("Age", id = "age"),
+                      shinydashboardPlus::boxDropdownItem("Gender", id = "gender")
+                      
+                    ),
+                    
+                    plotOutput("demo_plot") |>
+                      shinycssloaders::withSpinner(type = 8)
+                  )
                 )
               )
-            ))
+          )
+        )
       ),
       
       # DATA TABLE ----------------------------------------------------------

--- a/ui.R
+++ b/ui.R
@@ -61,10 +61,10 @@ ui <- (dashboardPage(
             id = "top-row",
             # value box row
             splitLayout(
-              cellArgs = list(style = "padding-right: 12px"),
+              cellArgs = list(style = "padding-right: 12px;"),
               # datetime data were last updated - value box acts as link to ss proj
               tags$a(
-                href = "https://seasketch.org/belize/app",
+                href = "https://seasketch.org/peter/app",
                 target = "_blank",
                 valueBoxOutput("data_update", width = NULL)
               ),

--- a/ui.R
+++ b/ui.R
@@ -67,11 +67,21 @@ ui <- (dashboardPage(
                 href = "https://seasketch.org/peter/app",
                 target = "_blank",
                 valueBoxOutput("data_update", width = NULL)
-              ),
+              ) |> 
+                # tooltip info when hovering over value boxes
+                shinyBS::tipify("Click to go to the SeaSketch project page.",
+                                # quote syntax overcomes tipify's flawed option parsing: https://shorturl.at/orA16
+                                options = list("delay': {show: 1000, hide: 50}, 'container" = "body")),
               # value boxes with response and representation figures
-              valueBoxOutput("individual_respondents", width = NULL),
-              valueBoxOutput("individuals_represented", width = NULL),
-              valueBoxOutput("sector_responses", width = NULL)
+              valueBoxOutput("individual_respondents", width = NULL) |> 
+                shinyBS::tipify(title = "The number of survey submissions.",
+                                options = list("delay': {show: 1000, hide: 50}, 'container" = "body")),
+              valueBoxOutput("individuals_represented", width = NULL) |> 
+                shinyBS::tipify(title = "The total number of participants represented by individual and group responses.",
+                                options = list("delay': {show: 1000, hide: 50}, 'container" = "body")),
+              valueBoxOutput("sector_responses", width = NULL) |> 
+                shinyBS::tipify(title = "The sum of the number of sectors represented in each response.",
+                                options = list("delay': {show: 1000, hide: 50}, 'container" = "body")),
             )
           ),
           

--- a/ui.R
+++ b/ui.R
@@ -55,72 +55,42 @@ ui <- (dashboardPage(
         div(
           id = "overview-tab",
           ## value boxes ----
-            width = "100%",
+          width = "100%",
+          
+          div(
+            id = "top-row",
+            # value box row
+            splitLayout(
+              cellArgs = list(style = "padding-right: 12px"),
+              # datetime data were last updated - value box acts as link to ss proj
+              tags$a(
+                href = "https://seasketch.org/belize/app",
+                target = "_blank",
+                valueBoxOutput("data_update", width = NULL)
+              ),
+              # value boxes with response and representation figures
+              valueBoxOutput("individual_respondents", width = NULL),
+              valueBoxOutput("individuals_represented", width = NULL),
+              valueBoxOutput("sector_responses", width = NULL)
+            )
+          ),
+          
+          ## target table ----
+          div(
+            id = "target-box",
             
-            # top row of boxes
-            div(
-              class = "col-sm-12 col-md-12 col-lg-12",
-              id = "top-row",
-              
-              # latest data and island option stack
-              div(
-                id = "data-island-stack",
-                class = "col-sm-6 col-md-6 col-lg-3",
-                
-                # latest data text
-                div(
-                  id = "latest-data",
-                  
-                  div(id = "latest-data-box",
-                      box(
-                        tags$a(
-                          href = seasketch_url,
-                          target = "_blank",
-                          img(src = "images/seasketch-logo.png",
-                              style = "height: 35px; margin-bottom: 17px; margin-top: 10px;"),
-                          width = "100%"
-                        ),
-                        
-                        uiOutput("latest_data"),
-                        width = "100%"
-                      ))
-                ),
+            shinydashboardPlus::box(
+              title = "Targets",
+              width = 12,
+              align = "center",
+              collapsible = TRUE,
+              dropdownMenu = shinydashboardPlus::boxDropdown(
+                shinydashboardPlus::boxDropdownItem("Save target changes", id = "save_targets")
               ),
               
-              # value box row
-              div(
-                id = "value-box-row",
-                class = "col-sm-12 col-md-12 col-lg-12",
-                
-                # value boxes with response and representation figures
-                div(class = "col-sm-4 col-md-4 col-lg-4",
-                    valueBoxOutput("individual_respondents", width = "33%")),
-                
-                div(class = "col-sm-4 col-md-4 col-lg-4",
-                    valueBoxOutput("individuals_represented", width = "33%")),
-                
-                div(class = "col-sm-4 col-md-4 col-lg-4",
-                    valueBoxOutput("sector_responses", width = "33%"))
-              )
+              DT::dataTableOutput("target_table") |>
+                shinycssloaders::withSpinner(type = 8)
             ),
-            
-            ## target table ----
-            div(
-              id = "target-box",
-              class = "col-sm-12 col-md-12 col-lg-12",
-              
-              shinydashboardPlus::box(
-                title = "Targets",
-                width = 12,
-                align = "center",
-                collapsible = TRUE,
-                dropdownMenu = shinydashboardPlus::boxDropdown(
-                  shinydashboardPlus::boxDropdownItem("Save target changes", id = "save_targets")
-                ),
-                
-                DT::dataTableOutput("target_table") |>
-                  shinycssloaders::withSpinner(type = 8)
-              )
           ),
           
           

--- a/ui.R
+++ b/ui.R
@@ -55,7 +55,6 @@ ui <- (dashboardPage(
         div(
           id = "overview-tab",
           ## value boxes ----
-          fluidRow(
             width = "100%",
             
             # top row of boxes
@@ -71,7 +70,7 @@ ui <- (dashboardPage(
                 # latest data text
                 div(
                   id = "latest-data",
-                  class = "col-sm-12 col-md-12 col-lg-12",
+                  
                   div(id = "latest-data-box",
                       box(
                         tags$a(
@@ -91,7 +90,7 @@ ui <- (dashboardPage(
               # value box row
               div(
                 id = "value-box-row",
-                class = "col-sm-12 col-md-12 col-lg-9",
+                class = "col-sm-12 col-md-12 col-lg-12",
                 
                 # value boxes with response and representation figures
                 div(class = "col-sm-4 col-md-4 col-lg-4",
@@ -122,7 +121,6 @@ ui <- (dashboardPage(
                 DT::dataTableOutput("target_table") |>
                   shinycssloaders::withSpinner(type = 8)
               )
-            )
           ),
           
           

--- a/www/style.css
+++ b/www/style.css
@@ -146,8 +146,13 @@ html, body {
  }
  
  #top-row {
+   display:inline-block; 
    padding: 0px;
    margin: 0px;
+   align-items: center !important;
+   justify-content: center !important;
+   display: flex;
+   flex-direction: column;
  }
  
   #latest-data {
@@ -172,6 +177,7 @@ html, body {
  }
  
  #value-box-row {
+   display:inline-block !important; 
    padding:0px;
    max-width: 900px;
  }
@@ -186,7 +192,7 @@ html, body {
  }
  
  #target-box {
-   max-width: 1200px;
+   max-width: 1300px;
    padding-right: 0;
    padding-left: 0;
  }
@@ -196,21 +202,23 @@ html, body {
  }
  
  #demo-plot-box {
-   padding-right: 0;
+   padding-right: 20;
    padding-left: 0;
  }
  
  #demo_plot {
+  margin-right: 20;
   height: 480px !important;
  }
  
   #resp_plot {
+  margin-left: 20;
   height: 480px !important;
  }
  
  #resp-plot-box {
    padding-right: 0;
-   padding-left: 0;
+   padding-left: 20;
  }
 
 #resp-plot-box > div > div > div.box-body > div.direct-chat-contacts-open {
@@ -250,7 +258,6 @@ html, body {
  }
  
  #dt-box {
-   width: 2000px;
    overflow-x: auto !important;
  }
  

--- a/www/style.css
+++ b/www/style.css
@@ -171,26 +171,31 @@ html, body {
  }
  
   #data_update > div > div {
-   padding-top: 2vh;
+   padding-top: 1.5vh;
    padding-left: 1vh;
  }
  
- /* "Data Updated:" */
+ /* "Responses Updated:" */
  #data_update > div > div > h3 {
-   font-size: 18px;
-   font-weight: normal;
+   font-size: 16px;
+   font-weight: 600;
+   line-height: 120%;
  }
  
  /* datetime */
  #data_update > div > div > p {
-   font-size: 20px;
-   font-weight: bold;
+   font-size: 22px;
+   font-weight: 900;
+   color: #009AD3;
  }
  
+ /* database icon */
  #data_update > div > div.icon-large {
    right: 2vh; 
    top: -1vh; 
    font-size: 38px;
+   color: #00A6E1;
+   opacity: 0.8;
  }
  
   #latest-data {

--- a/www/style.css
+++ b/www/style.css
@@ -20,7 +20,6 @@ html, body {
   background-color: #0087B7;
 }
 
-
 /* box titles */
 .box-title {
   font-weight: bold; 
@@ -138,8 +137,17 @@ html, body {
  
  /* ---- overview page ---- */
  
+ /* center all elements on overview page*/
+#overview-tab {
+   align-items: center !important;
+   justify-content: center !important;
+   display: flex;
+   flex-direction: column;
+ }
+ 
  #top-row {
    padding: 0px;
+   margin: 0px;
  }
  
   #latest-data {
@@ -204,7 +212,7 @@ html, body {
    padding-right: 0;
    padding-left: 0;
  }
- 
+
 #resp-plot-box > div > div > div.box-body > div.direct-chat-contacts-open {
    max-width: 150px !important;
  }
@@ -242,6 +250,7 @@ html, body {
  }
  
  #dt-box {
+   width: 2000px;
    overflow-x: auto !important;
  }
  

--- a/www/style.css
+++ b/www/style.css
@@ -20,8 +20,8 @@ html, body {
 }
 
 .shiny-split-layout {
-  max-width: 1200px;
-  margin-right: 3px !important;
+  max-width: 1205px;
+  margin-right: 10px !important;
 }
 
 /* box titles */
@@ -157,7 +157,7 @@ html, body {
    justify-content: center !important;
    display: flex;
    flex-direction: column;
-   width: 95%;
+   width: 98%;
  }
  
  #data_update > div:hover {
@@ -167,7 +167,7 @@ html, body {
  #data_update > div {
    color: #2E4052 !important;
    background-color: white !important;
-   margin-left: 1.5px !important;
+   margin-left: 8px !important;
  }
  
   #data_update > div > div {
@@ -192,7 +192,7 @@ html, body {
  /* database icon */
  #data_update > div > div.icon-large {
    right: 2vh; 
-   top: -1vh; 
+   top: -0.8vh; 
    font-size: 38px;
    color: #00A6E1;
    opacity: 0.8;
@@ -215,7 +215,7 @@ html, body {
  }
  
  #target-box {
-   width: 98%;
+   width: 100%;
    max-width: 1230px;
    padding-right: 0;
    padding-left: 0;

--- a/www/style.css
+++ b/www/style.css
@@ -16,8 +16,12 @@ html, body {
 }
 
 .skin-blue .main-header .logo {
-  
   background-color: #0087B7;
+}
+
+.shiny-split-layout {
+  max-width: 1200px;
+  margin-right: 3px !important;
 }
 
 /* box titles */
@@ -153,6 +157,40 @@ html, body {
    justify-content: center !important;
    display: flex;
    flex-direction: column;
+   width: 95%;
+ }
+ 
+ #data_update > div:hover {
+  background-color: #DEE5FD !important;
+}
+ 
+ #data_update > div {
+   color: #2E4052 !important;
+   background-color: white !important;
+   margin-left: 1.5px !important;
+ }
+ 
+  #data_update > div > div {
+   padding-top: 2vh;
+   padding-left: 1vh;
+ }
+ 
+ /* "Data Updated:" */
+ #data_update > div > div > h3 {
+   font-size: 18px;
+   font-weight: normal;
+ }
+ 
+ /* datetime */
+ #data_update > div > div > p {
+   font-size: 20px;
+   font-weight: bold;
+ }
+ 
+ #data_update > div > div.icon-large {
+   right: 2vh; 
+   top: -1vh; 
+   font-size: 38px;
  }
  
   #latest-data {
@@ -160,26 +198,6 @@ html, body {
    height: 79px;
    text-align: center;
    font-size: 18px !important;
- }
- 
- #latest-data-box {
-   margin-bottom: 10px;
- }
- 
-  #island-selector {
-   height: 74px;
- }
- 
- #data-island-stack {
-   padding: 0px; 
-   max-width: 300px;
-   height: 153px;
- }
- 
- #value-box-row {
-   display:inline-block !important; 
-   padding:0px;
-   max-width: 900px;
  }
  
  #sec-resp-metric-select {
@@ -192,17 +210,18 @@ html, body {
  }
  
  #target-box {
-   max-width: 1300px;
+   width: 98%;
+   max-width: 1230px;
    padding-right: 0;
    padding-left: 0;
  }
  
  #plots-row {
-   max-width: 1172px !important;
+   max-width: 1230px !important;
  }
  
  #demo-plot-box {
-   padding-right: 20;
+   padding-right: 0;
    padding-left: 0;
  }
  
@@ -211,14 +230,14 @@ html, body {
   height: 480px !important;
  }
  
-  #resp_plot {
-  margin-left: 20;
-  height: 480px !important;
- }
- 
  #resp-plot-box {
    padding-right: 0;
-   padding-left: 20;
+   padding-left: 0;
+ }
+ 
+ #resp_plot {
+  margin-left: 20;
+  height: 480px !important;
  }
 
 #resp-plot-box > div > div > div.box-body > div.direct-chat-contacts-open {


### PR DESCRIPTION
Overview page formatting
- centered all elements on page
- redesigned data update box

tooltips
- added tooltip info to top row of boxes explaining what the values mean

Improved data filtering
- changed the `response_id` column to `character` type in `make_datatable()` so that you can filter individual ids instead of using the default range slider used for integer columns